### PR TITLE
Fix usage of DialogProvider so it matches the docs

### DIFF
--- a/src/__tests__/index.spec.tsx
+++ b/src/__tests__/index.spec.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react"
 import { Simulate, act } from "react-dom/test-utils"
 import { render, unmountComponentAtNode } from "react-dom"
-import DialogProvider, { useDialog } from ".."
+import { DialogProvider, useDialog } from ".."
 
 let root: HTMLElement | undefined = undefined
 beforeEach(() => {

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -43,7 +43,7 @@ export const Dialog = createContext<DialogValue>({
 
 const defaultLabels = { ok: "OK", cancel: "Cancel" }
 
-export default function DialogProvider({
+export function DialogProvider({
   layout = DefaultLayout,
   container = document.body,
   children

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { default } from "./context"
+export { DialogProvider } from "./context"
 export { useDialog } from "./hooks"
 export { DefaultLayout } from "./layout"
 export { LayoutProps } from "./types"


### PR DESCRIPTION
Hi,

I fixed the exports from the package because the dialog provider wasn't being exported like you mention in the docs for this package. 

import { DialogProvider, useDialog } from "react-async-dialog"

Nice component by the way. Very useful. 

Cheers,

Darren